### PR TITLE
Implement custom tags for xbbcode-parser

### DIFF
--- a/actions/AAJ-850mm/server.js
+++ b/actions/AAJ-850mm/server.js
@@ -5,15 +5,58 @@ function(properties, context) {
   // Recebe o BBCode do Bubble
   const input_bbcode = properties.input_bbcode || '';
 
+  // Instancia o parser, quando possível
+  const parser = XBBCODE.Parser ? new XBBCODE.Parser() : XBBCODE;
+
+  // Registro de tags personalizadas caso o método exista
+  if (typeof parser.registerTag === 'function' || typeof parser.addTags === 'function') {
+    const register = parser.registerTag || parser.addTags.bind(parser);
+
+    register('img', {
+      openTag: function(params, content) {
+        let url = content || params || '';
+        let sizeAttr = '';
+
+        if (params && params !== url) {
+          const match = params.match(/^(\d+)(x(\d+))?$/);
+          if (match) {
+            const width = match[1];
+            const height = match[3];
+            sizeAttr = ` width="${width}"` + (height ? ` height="${height}"` : '');
+          }
+        }
+
+        return `<img src="${url}"${sizeAttr} alt="">`;
+      },
+      closeTag: function() {
+        return '';
+      },
+      displayContent: false
+    });
+
+    register('font', {
+      openTag: function(params) {
+        const family = params || 'inherit';
+        return `<span style="font-family:${family}">`;
+      },
+      closeTag: function() {
+        return '</span>';
+      }
+    });
+  }
+
   // Converte usando xbbcode
-  const result = XBBCODE.process({
+  const result = (parser.process || parser.parse).call(parser, {
     text: input_bbcode,
     removeMisalignedTags: false,
     addInLineBreaks: true // Se quiser <br> automático para quebras de linha
   });
 
-  // O HTML convertido fica em result.html
+  // Garante que entidades como &quot; sejam decodificadas
+  let html = result.html || result;
+  html = html.replace(/&quot;/g, '"');
+
   return {
-    html: result.html
+    html: html
   };
 }


### PR DESCRIPTION
## Summary
- extend the xbbcode-parser action to register custom `[img]` and `[font]` tags
- decode HTML entities like `&quot;` after conversion

## Testing
- `npm install` *(fails: 403 Forbidden for xbbcode-parser)*

------
https://chatgpt.com/codex/tasks/task_e_684707fe95cc8326810e193ba93ec626